### PR TITLE
hashCode can collide with item ids from data, leading to RecyclerView crash

### DIFF
--- a/library/src/main/java/com/twotoasters/sectioncursoradapter/adapter/datahandler/SectionDataWrapper.java
+++ b/library/src/main/java/com/twotoasters/sectioncursoradapter/adapter/datahandler/SectionDataWrapper.java
@@ -105,7 +105,7 @@ public class SectionDataWrapper<S, T, D extends DataHandler<T>> extends DataWrap
         int wrappedPosition = getWrappedPosition(listPosition);
 
         return wrappedPosition == RecyclerView.NO_POSITION
-                ? getSectionFromListPosition(listPosition).hashCode()
+                ? Integer.MAX_VALUE - listPosition
                 : super.getItemId(wrappedPosition);
     }
 


### PR DESCRIPTION
If the hashCode for a section is equal to the first itemId of a section, RecyclerView will eventually complain and crash with
java.lang.IllegalStateException: Two different ViewHolders have the same stable ID. Stable IDs in your adapter MUST BE unique and SHOULD NOT change.
This pull requests uses different approach for calculating ids for sections.
